### PR TITLE
fix: install @vue/cli-service before building

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "vocalotomo-dummy-builder",
   "version": "0.1.0",
   "scripts": {
+    "heroku-prebuild": "npm install -g @vue/cli-service",
     "postinstall": "npm install --prefix frontend && npm run build --prefix frontend"
   }
 }


### PR DESCRIPTION
It is normally devDependencies and not installed on production server
like heroku.
TODO: other packages in devDependencies also needed?