### PR TITLE
fix: disable production in install

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "vocalotomo-dummy-builder",
   "version": "0.1.0",
   "scripts": {
-    "heroku-prebuild": "npm install -g @vue/cli-service",
-    "postinstall": "npm install --prefix frontend && npm run build --prefix frontend"
+    "postinstall": "npm install --production false --prefix frontend && npm run build --prefix frontend"
   }
 }


### PR DESCRIPTION
特別に @vue/cli-service だけインストールしてもモジュール不足のエラーが出
たので。

そもそもおそらく Heroku 上で Vue のビルドをするということ自体があまり正
しくない使い方なんだと思うけど、このためだけの GitHub Actions と別のブラ
ンチを用意して CI -> デプロイというのもなあ...と思うので